### PR TITLE
Capture relevant logs only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 	* Scripts are now passed via `--script`. A script is now always required.
 * Added support for any place file, not just ones that rbx-dom supports.
 * Fixed many panics, replacing them with graceful error messages.
+* Switched from LogService capture to injection of stubs for print & warn, and use of xpcall to capture relevant logs only
 
 ## 0.2.0
 * **TODO**

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,6 @@ fn run(options: Options) -> Result<i32, anyhow::Error> {
             RobloxMessage::Output { level, body } => {
                 let colored_body = match level {
                     OutputLevel::Print => body.normal(),
-                    OutputLevel::Info => body.cyan(),
                     OutputLevel::Warning => body.yellow(),
                     OutputLevel::Error => body.red(),
                 };

--- a/src/message_receiver.rs
+++ b/src/message_receiver.rs
@@ -26,7 +26,6 @@ pub enum RobloxMessage {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 pub enum OutputLevel {
     Print,
-    Info,
     Warning,
     Error,
 }


### PR DESCRIPTION
## Issue

Presently, `run-in-roblox` uses LogService to capture messages. This is good, because it allows its output to correspond exactly to the one in Roblox.

However, it also means logs not relevant to `--script` are captured. This could cause `run-in-roblox` to exit non-zero due to an error from an other plugin, or perhaps an issue downloading sounds (unsure if these are still error context).

We can use the `xpcall` calls to capture the errors from our script, and no longer listen to LogService errors to ignore others. However, with some logs being captured outside of LogService, this would lead to ordering issues as the LogService event does not fire syncronously. For example, we might see a print before an error appear after it.

## Proposed soloution

The approach I have taken here is stubbing print and warn in the users code being executed. This way, we can ensure they will arrive in the correct order. There are still a few downsides with this:

- Previously, we could support the 'Info' level logs from `TestService`. Doing that here while maintaining correct log order would involve much more complex environment stubs for TestService. As TestService's own testing / logging functions are rarely used, I have dropped support for them.
- By modifying the environment, we'll lose access to Luau optimisations. 

This isn't a clear cut one, so I'm completely open to alternative approaches here.
