### PR TITLE
Implemented optional parameters for universe/place-id

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,16 @@ struct Options {
     #[structopt(long("place"))]
     place_path: Option<PathBuf>,
 
+    /// The universe of the place id to open in Roblox Studio. If not specified,
+    /// the place-id will not be used
+    #[structopt(long("universe"))]
+    universe_id: Option<u64>,
+
+    /// The place id to open in Roblox Studio. If not specified, the place-id
+    /// will not be used
+    #[structopt(long("place-id"))]
+    place_id: Option<u64>,
+
     /// A path to the script to run in Roblox Studio.
     ///
     /// The script will be run at plugin-level security.
@@ -30,11 +40,13 @@ struct Options {
 }
 
 fn run(options: Options) -> Result<i32, anyhow::Error> {
+    // Additional parameters that we may want to pass to roblox Studio
+    let mut params = vec![];
+
     // Create a temp directory to house our place, even if a path is given from
     // the command line. This helps ensure Studio won't hang trying to tell the
     // user that the place is read-only because of a .lock file.
     let temp_place_folder = tempdir()?;
-    let temp_place_path;
 
     match &options.place_path {
         Some(place_path) => {
@@ -44,16 +56,39 @@ fn run(options: Options) -> Result<i32, anyhow::Error> {
                 .to_str()
                 .ok_or_else(|| anyhow!("Place file extension had invalid Unicode"))?;
 
-            temp_place_path = temp_place_folder
+            let temp_place_path = temp_place_folder
                 .path()
                 .join(format!("run-in-roblox-place.{}", extension));
 
             fs::copy(place_path, &temp_place_path)?;
+
+            params.push(format!("{}", temp_place_path.display()));
         }
         None => {
-            unimplemented!("run-in-roblox with no place argument");
+            // Fall back to testing universe and place-id
+            // If we have both a universe and place id, we need to pass them to Studio
+            match (&options.universe_id, &options.place_id) {
+                (Some(universe_id), Some(place_id)) => {
+                    params.extend_from_slice(&vec![
+                        // This tells studio to open the place
+                        "-task".to_string(),
+                        "EditPlace".to_string(),
+                        // The universe to open
+                        "-universeId".to_string(),
+                        universe_id.to_string(),
+                        // The place to open
+                        "-placeId".to_string(),
+                        place_id.to_string(),
+                    ]);
+                }
+                _ => {
+                    unimplemented!("run-in-roblox must have a place path or universe and place id");
+                }
+            };
         }
     }
+
+
 
     let script_contents = fs::read_to_string(&options.script_path)?;
 
@@ -64,9 +99,9 @@ fn run(options: Options) -> Result<i32, anyhow::Error> {
 
     let place_runner = PlaceRunner {
         port: 50312,
-        place_path: temp_place_path.clone(),
         server_id: server_id.clone(),
         lua_script: script_contents.clone(),
+        args: params,
     };
 
     let (sender, receiver) = mpsc::channel();

--- a/src/place_runner.rs
+++ b/src/place_runner.rs
@@ -26,8 +26,8 @@ impl Drop for KillOnDrop {
 
 pub struct PlaceRunner {
     pub port: u16,
-    pub place_path: PathBuf,
     pub server_id: String,
+    pub args: Vec<String>,
     pub lua_script: String,
 }
 
@@ -56,7 +56,7 @@ impl PlaceRunner {
 
         let _studio_process = KillOnDrop(
             Command::new(studio_install.application_path())
-                .arg(format!("{}", self.place_path.display()))
+                .args(&self.args)
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .spawn()?,


### PR DESCRIPTION
This PR implements the ability to specify what place you want to open in studio, and if no place is specified it'll open up the default baseplate. As well as implements the ability to specify extra parameters to pass extra parameters to studio (in rust), which can allow for additional functionality if need be.

Resolves: #24 #22 